### PR TITLE
DCOS-57890-Investigate-manual-backup-restore-s3-updated

### DIFF
--- a/frameworks/elastic/src/main/dist/svc.yml
+++ b/frameworks/elastic/src/main/dist/svc.yml
@@ -67,6 +67,7 @@ pods:
           ./scripts/install-plugins.sh
           ./scripts/setup-java-policy.sh
           ./scripts/customize-log4j2.sh
+          ./elasticsearch-{{ELASTIC_VERSION}}/bin/elasticsearch-keystore create
 
           exec ./elasticsearch-{{ELASTIC_VERSION}}/bin/elasticsearch
         env:
@@ -170,6 +171,7 @@ pods:
           ./scripts/install-plugins.sh
           ./scripts/setup-java-policy.sh
           ./scripts/customize-log4j2.sh
+          ./elasticsearch-{{ELASTIC_VERSION}}/bin/elasticsearch-keystore create
 
           exec ./elasticsearch-{{ELASTIC_VERSION}}/bin/elasticsearch
         env:
@@ -271,6 +273,7 @@ pods:
           ./scripts/install-plugins.sh
           ./scripts/setup-java-policy.sh
           ./scripts/customize-log4j2.sh
+          ./elasticsearch-{{ELASTIC_VERSION}}/bin/elasticsearch-keystore create
 
           exec ./elasticsearch-{{ELASTIC_VERSION}}/bin/elasticsearch
         env:
@@ -433,6 +436,7 @@ pods:
           ./scripts/install-plugins.sh
           ./scripts/setup-java-policy.sh
           ./scripts/customize-log4j2.sh
+          ./elasticsearch-{{ELASTIC_VERSION}}/bin/elasticsearch-keystore create
 
           exec ./elasticsearch-{{ELASTIC_VERSION}}/bin/elasticsearch
         env:

--- a/frameworks/elastic/tests/test_backup_restore.py
+++ b/frameworks/elastic/tests/test_backup_restore.py
@@ -1,0 +1,139 @@
+import pytest
+import os
+from typing import Iterator
+import sdk_install
+import sdk_hosts
+import sdk_cmd
+import sdk_tasks
+from tests import config
+
+
+@pytest.fixture(scope="module", autouse=True)
+def configure_package(configure_security: None) -> Iterator[None]:
+
+    try:
+        service_options = {"elasticsearch": {"plugins": "repository-s3"}}
+        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+        sdk_install.install(
+            config.PACKAGE_NAME,
+            config.SERVICE_NAME,
+            config.DEFAULT_TASK_COUNT,
+            additional_options=service_options,
+        )
+
+        yield  # let the test session execute
+    finally:
+        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+
+
+@pytest.fixture(autouse=True)
+def pre_test_setup() -> None:
+    sdk_tasks.check_running(config.SERVICE_NAME, config.DEFAULT_TASK_COUNT)
+    config.wait_for_expected_nodes_to_exist(task_count=config.DEFAULT_TASK_COUNT)
+
+
+@pytest.mark.aws
+@pytest.mark.sanity
+def test_backup_restore():
+    key_id = os.getenv("AWS_ACCESS_KEY_ID")
+    if not key_id:
+        assert (
+            False
+        ), 'AWS credentials are required for this test. Disable test with e.g. TEST_TYPES="sanity and not aws"'
+    task_list = sdk_tasks.get_service_tasks(config.SERVICE_NAME)
+    for task in task_list:
+        sdk_cmd.service_task_exec(
+            config.SERVICE_NAME,
+            task.name,
+            "bash -c \"export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*/);  echo '{}' | ./elasticsearch-*/bin/elasticsearch-keystore add --stdin s3.client.default.access_key\"".format(
+                os.getenv("AWS_ACCESS_KEY_ID")
+            ),
+        )
+        sdk_cmd.service_task_exec(
+            config.SERVICE_NAME,
+            task.name,
+            "bash -c \"export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*/);  echo '{}' | ./elasticsearch-*/bin/elasticsearch-keystore add --stdin s3.client.default.secret_key\"".format(
+                os.getenv("AWS_SECRET_ACCESS_KEY")
+            ),
+        )
+        sdk_cmd.service_task_exec(
+            config.SERVICE_NAME,
+            task.name,
+            "bash -c \"export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*/);  echo '{}' | ./elasticsearch-*/bin/elasticsearch-keystore add --stdin s3.client.default.session_token\"".format(
+                os.getenv("AWS_SESSION_TOKEN")
+            ),
+        )
+        sdk_cmd.service_task_exec(
+            config.SERVICE_NAME,
+            task.name,
+            'bash -c "export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*/); ./elasticsearch-*/bin/elasticsearch-keystore list"',
+        )
+
+    sdk_cmd.service_task_exec(
+        config.SERVICE_NAME,
+        "master-0-node",
+        " /opt/mesosphere/bin/curl -i -XPOST -H 'Content-type: application/json' \"http://"
+        + sdk_hosts.vip_host(config.SERVICE_NAME, "coordinator", 9200)
+        + '/_nodes/reload_secure_settings"',
+    )
+    sdk_cmd.service_task_exec(
+        config.SERVICE_NAME,
+        "master-0-node",
+        '  /opt/mesosphere/bin/curl -i -XPOST -H \'Content-type: application/json\' -d \'{"name": "SwamiVivekananda"}\' "http://'
+        + sdk_hosts.vip_host(config.SERVICE_NAME, "coordinator", 9200)
+        + '/customer/entry/99?pretty"',
+    )
+    sdk_cmd.service_task_exec(
+        config.SERVICE_NAME,
+        "master-0-node",
+        ' /opt/mesosphere/bin/curl -i -XPUT -H \'Content-type: application/json\' -d \'{"type": "s3", "settings": {"bucket": "elastic-bkp-bucket", "region": "us-east-1"} }\' "http://'
+        + sdk_hosts.vip_host(config.SERVICE_NAME, "coordinator", 9200)
+        + '/_snapshot/s3_repo?verify=false&pretty"',
+    )
+
+    # take backup
+    sdk_cmd.service_task_exec(
+        config.SERVICE_NAME,
+        "master-0-node",
+        " /opt/mesosphere/bin/curl -i -XPUT -H 'Content-type: application/json' \"http://"
+        + sdk_hosts.vip_host(config.SERVICE_NAME, "coordinator", 9200)
+        + '/_snapshot/s3_repo/snap1?"',
+    )
+
+    # Delete data before executing restore
+    sdk_cmd.service_task_exec(
+        config.SERVICE_NAME,
+        "master-0-node",
+        " /opt/mesosphere/bin/curl -i -XDELETE -H 'Content-type: application/json' \"http://"
+        + sdk_hosts.vip_host(config.SERVICE_NAME, "coordinator", 9200)
+        + '/*"',
+    ) 
+
+    _, output, _ = sdk_cmd.service_task_exec(
+        config.SERVICE_NAME,
+        "master-0-node",
+        " /opt/mesosphere/bin/curl -i -u elastic:changeme -H 'Content-type: application/json' \"http://"
+        + sdk_hosts.vip_host(config.SERVICE_NAME, "coordinator", 9200)
+        + '/customer/entry/99?pretty"',
+    )
+
+    assert '"name" : "SwamiVivekananda"' not in output
+
+    # restore data
+    sdk_cmd.service_task_exec(
+        config.SERVICE_NAME,
+        "master-0-node",
+        " /opt/mesosphere/bin/curl -i -XPOST -H 'Content-type: application/json' \"http://"
+        + sdk_hosts.vip_host(config.SERVICE_NAME, "coordinator", 9200)
+        + '/_snapshot/s3_repo/snap1/_restore"',
+    )
+
+    _, output, _ = sdk_cmd.service_task_exec(
+        config.SERVICE_NAME,
+        "master-0-node",
+        " /opt/mesosphere/bin/curl -i -u elastic:changeme -H 'Content-type: application/json' \"http://"
+        + sdk_hosts.vip_host(config.SERVICE_NAME, "coordinator", 9200)
+        + '/customer/entry/99?pretty"',
+    )
+
+    assert '"name" : "SwamiVivekananda"' in output


### PR DESCRIPTION
To add support for backup and restore, we had to:

Create a keystore before starting elasticsearch modules.
AWS credentials are stored in keystore. That is why keystore is created.

Users will have to include repository-s3 plugin.