### PR TITLE
COPS-5528: Make exporter port Named VIP

### DIFF
--- a/frameworks/elastic/src/main/dist/svc.yml
+++ b/frameworks/elastic/src/main/dist/svc.yml
@@ -316,7 +316,11 @@ pods:
     count: 0
     {{/PROMETHEUS_EXPORTER_ENABLED}}
     allow-decommission: true
-    # TODO: Apply network labels after adding port labels support in SDK
+    {{#ENABLE_VIRTUAL_NETWORK}}
+    networks:
+      {{VIRTUAL_NETWORK_NAME}}:
+        labels: {{VIRTUAL_NETWORK_PLUGIN_LABELS}}
+    {{/ENABLE_VIRTUAL_NETWORK}}
     uris:
       - {{ELASTICSEARCH_JAVA_URI}}
       - {{PROMETHEUS_EXPORTER_URI}}
@@ -330,6 +334,9 @@ pods:
           exporter:
             port: 0
             env-key: METRICS_PORT
+            vip:
+              prefix: exporter
+              port: 9114
         volume:
           path: "container-path"
           type: {{PROMETHEUS_EXPORTER_DISK_TYPE}}


### PR DESCRIPTION
Resolve [COPS-5528](https://jira.d2iq.com/browse/COPS-5528)
- Enable virtual network back to exporter task
- Make exporter port VIP, so SDK would attach **_network-scope_**  label [here](https://github.com/mesosphere/dcos-commons/blob/451b959b40464535716bece5217ff925eb977e66/sdk/scheduler/src/main/java/com/mesosphere/sdk/offer/evaluate/NamedVIPEvaluationStage.java#L53) 