### PR TITLE
[COPS-6293] Add password for default superuser

### DIFF
--- a/frameworks/elastic/src/main/dist/security-pass.sh.mustache
+++ b/frameworks/elastic/src/main/dist/security-pass.sh.mustache
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+{{#SECURITY_ENABLED}}
+printf {{ELASTICSEARCH_HEALTH_USER_PASSWORD}} | .${MESOS_SANDBOX}/elasticsearch-{{ELASTIC_VERSION}}/bin/elasticsearch-keystore add -x
+curl -u{{ELASTICSEARCH_HEALTH_USER}}:{{ELASTICSEARCH_HEALTH_USER_PASSWORD}} -XPUT -H 'Content-Type: application/json' '{{ELASTICSEARCH_HTTP_PROTOCOL}}://$TASK_NAME.$FRAMEWORK_HOST:$PORT_HTTP/_xpack/security/user/kibana/_password 75' -d '{ "password":{{ELASTICSEARCH_HEALTH_USER_PASSWORD}} }'
+curl -u{{ELASTICSEARCH_HEALTH_USER}}:{{ELASTICSEARCH_HEALTH_USER_PASSWORD}} -XPUT -H 'Content-Type: application/json' '{{ELASTICSEARCH_HTTP_PROTOCOL}}://$TASK_NAME.$FRAMEWORK_HOST:$PORT_HTTP/_xpack/security/user/elastic/_password 75' -d '{ "password":{{ELASTICSEARCH_HEALTH_USER_PASSWORD}} }'
+{{/SECURITY_ENABLED}}

--- a/frameworks/elastic/src/main/dist/svc.yml
+++ b/frameworks/elastic/src/main/dist/svc.yml
@@ -67,6 +67,7 @@ pods:
           ./scripts/install-plugins.sh
           ./scripts/setup-java-policy.sh
           ./scripts/customize-log4j2.sh
+          ./scripts/security-pass.sh
 
           exec ./elasticsearch-{{ELASTIC_VERSION}}/bin/elasticsearch
         env:
@@ -96,6 +97,9 @@ pods:
           customize-log4j2.sh:
             template: customize-log4j2.sh
             dest: scripts/customize-log4j2.sh
+          security-pass.sh:
+            template: security-pass.sh.mustache
+            dest: scripts/security-pass.sh
         readiness-check:
           cmd: "curl -k -I -s -f -u {{ELASTICSEARCH_HEALTH_USER}}:{{ELASTICSEARCH_HEALTH_USER_PASSWORD}} {{ELASTICSEARCH_HTTP_PROTOCOL}}://$TASK_NAME.$FRAMEWORK_HOST:$PORT_HTTP"
           interval: {{MASTER_NODE_READINESS_CHECK_INTERVAL}}
@@ -170,6 +174,7 @@ pods:
           ./scripts/install-plugins.sh
           ./scripts/setup-java-policy.sh
           ./scripts/customize-log4j2.sh
+          ./scripts/security-pass.sh
 
           exec ./elasticsearch-{{ELASTIC_VERSION}}/bin/elasticsearch
         env:
@@ -197,6 +202,9 @@ pods:
           customize-log4j2.sh:
             template: customize-log4j2.sh
             dest: scripts/customize-log4j2.sh
+          security-pass.sh:
+            template: security-pass.sh.mustache
+            dest: scripts/security-pass.sh
         readiness-check:
           cmd: "curl -k -I -s -f -u {{ELASTICSEARCH_HEALTH_USER}}:{{ELASTICSEARCH_HEALTH_USER_PASSWORD}} {{ELASTICSEARCH_HTTP_PROTOCOL}}://$TASK_NAME.$FRAMEWORK_HOST:$PORT_HTTP"
           interval: {{DATA_NODE_READINESS_CHECK_INTERVAL}}
@@ -271,6 +279,7 @@ pods:
           ./scripts/install-plugins.sh
           ./scripts/setup-java-policy.sh
           ./scripts/customize-log4j2.sh
+          ./scripts/security-pass.sh
 
           exec ./elasticsearch-{{ELASTIC_VERSION}}/bin/elasticsearch
         env:
@@ -298,6 +307,9 @@ pods:
           customize-log4j2.sh:
             template: customize-log4j2.sh
             dest: scripts/customize-log4j2.sh
+          security-pass.sh:
+            template: security-pass.sh.mustache
+            dest: scripts/security-pass.sh
         readiness-check:
           cmd: "curl -k -I -s -f -u {{ELASTICSEARCH_HEALTH_USER}}:{{ELASTICSEARCH_HEALTH_USER_PASSWORD}} {{ELASTICSEARCH_HTTP_PROTOCOL}}://$TASK_NAME.$FRAMEWORK_HOST:$PORT_HTTP"
           interval: {{INGEST_NODE_READINESS_CHECK_INTERVAL}}
@@ -439,6 +451,7 @@ pods:
           ./scripts/install-plugins.sh
           ./scripts/setup-java-policy.sh
           ./scripts/customize-log4j2.sh
+          ./scripts/security-pass.sh
 
           exec ./elasticsearch-{{ELASTIC_VERSION}}/bin/elasticsearch
         env:
@@ -466,6 +479,9 @@ pods:
           customize-log4j2.sh:
             template: customize-log4j2.sh
             dest: scripts/customize-log4j2.sh
+          security-pass.sh:
+            template: security-pass.sh.mustache
+            dest: scripts/security-pass.sh
         readiness-check:
           cmd: "curl -k -I -s -f -u {{ELASTICSEARCH_HEALTH_USER}}:{{ELASTICSEARCH_HEALTH_USER_PASSWORD}} {{ELASTICSEARCH_HTTP_PROTOCOL}}://$TASK_NAME.$FRAMEWORK_HOST:$PORT_HTTP"
           interval: {{COORDINATOR_NODE_READINESS_CHECK_INTERVAL}}


### PR DESCRIPTION
Base Issue: [COPS-6293](https://jira.d2iq.com/browse/COPS-6293)

This PR:
- Fixes the case where the the elastic assumes the default "changeme" for the superuser.
- Add the way to set password for the superuser when security is enabled.