### PR TITLE
D2IQ-72496 (D2IQ-65349): Add configurable logrotate options for Elastic service

### DIFF
--- a/frameworks/elastic/universe/config.json
+++ b/frameworks/elastic/universe/config.json
@@ -62,6 +62,22 @@
           ],
           "default": "INFO"
         },
+        "logrotate_options": {
+          "description": "The logrotate options for the DC/OS service.",
+          "type": "object",
+          "properties": {
+            "stdout_max_size": {
+              "description": "Logrotate stdout max size. Sizes must be an integer of less than 2^64 and must be suffixed with a unit such as B (bytes), KB, MB, GB, or TB. There should be no whitespace between the integer and unit.",
+              "type": "string",
+              "default": "8MB"
+            },
+            "stderr_max_size": {
+              "description": "Logrotate stderr max size. Sizes must be an integer of less than 2^64 and must be suffixed with a unit such as B (bytes), KB, MB, GB, or TB. There should be no whitespace between the integer and unit.",
+              "type": "string",
+              "default": "8MB"
+            }
+          }
+        },
         "check": {
           "description": "Health check used to determine the scheduler health based on the status of the scheduler plans.",
           "type": "object",

--- a/frameworks/elastic/universe/marathon.json.mustache
+++ b/frameworks/elastic/universe/marathon.json.mustache
@@ -48,6 +48,8 @@
     "FRAMEWORK_PRINCIPAL": "{{service.service_account}}",
     "FRAMEWORK_LOG_LEVEL": "{{service.log_level}}",
     "PROMETHEUS_EXPORTER_URI" : "{{resource.assets.uris.prometheus-exporter-tar-gz}}",
+    "CONTAINER_LOGGER_LOGROTATE_MAX_STDOUT_SIZE": "{{service.logrotate_options.stdout_max_size}}",
+    "CONTAINER_LOGGER_LOGROTATE_MAX_STDERR_SIZE": "{{service.logrotate_options.stderr_max_size}}",
     {{#service.service_account_secret}}
     "DCOS_SERVICE_ACCOUNT_CREDENTIAL": "secrets/service-account.json",
     "MESOS_MODULES": "{\"libraries\":[{\"file\":\"libmesos-bundle\/lib\/mesos\/libdcos_security.so\",\"modules\":[{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\",\"parameters\":[{\"key\":\"service_account_credential\",\"value\":\"file://secrets/service-account.json\"}]},{\"name\":\"com_mesosphere_dcos_http_Authenticatee\",\"parameters\":[{\"key\":\"service_account_credential\",\"value\":\"file://secrets/service-account.json\"},{\"key\":\"jwt_exp_timeout\",\"value\":\"5mins\"},{\"key\":\"preemptive_refresh_duration\",\"value\":\"30mins\"}]}]}]}",


### PR DESCRIPTION
Relaunch #81  on behalf of @amatuk due to previous CI issues.

This patch allows the following env-vars to be altered:

CONTAINER_LOGGER_LOGROTATE_MAX_STDOUT_SIZE
CONTAINER_LOGGER_LOGROTATE_MAX_STDERR_SIZE